### PR TITLE
Fix packages in prep for upcoming work

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,35 +1,29 @@
-// Listening to github event pull_request.created to create a new openshift app based on the branch name used in the PR
-
-/* const yaml = require('js-yaml'); */
 const githubConn = require('./lib/github.js');
 const openshiftConn = require('./lib/openshift.js');
-const fs = require('fs');
 
 
 module.exports = robot => {
   console.log('probot-openshift-github-branches was loaded!');
 
-  robot.on('pull_request.opened', pr_new);
-  robot.on('pull_request.reopened', pr_new);
+  robot.on(['pull_request.opened', 'pull_request.reopened'], pr_new);
   robot.on('push', commit_push);
   robot.on('status', status);
   robot.on('pull_request.closed', pr_close);
   robot.on('deployment', deploy);
 
-  async function pr_new(event, context) {
-     // Event.payload.pull_request.title
-    githubConn.pr_opened(event, context);
-    openshiftConn.pr_opened(event);
+  async function pr_new(context) {
+    githubConn.pr_opened(context);
+    openshiftConn.pr_opened(context.event);
   }
 
-  async function commit_push(event, context) {
-    githubConn.push(event, context);
+  async function commit_push(context) {
+    githubConn.push(context);
   }
 
-  async function status(event, context) {
-    console.log('status caught');
-    event.payload.ref = event.payload.sha;
-    githubConn.status_for_commit(event, context);
+  async function status(context) {
+    robot.log('status caught');
+    context.event.payload.ref = context.event.payload.sha;
+    githubConn.status_for_commit(context);
   }
 
 /*
@@ -37,13 +31,14 @@ Async function pr_commit_push(event, context) {
     openshiftConn.pr_commit_push();
   }
 */
-  async function pr_close(event, context) {
+  async function pr_close(context) {
     // Const merged = context.issue.merged;
-    githubConn.pr_closed(event, context);
+    githubConn.pr_closed(context);
   }
 
-  async function deploy(event, context) {
-    openshiftConn.deploy(event);
-    githubConn.deploy(event, context);
+  async function deploy(context) {
+    openshiftConn.deploy(context);
+    githubConn.deploy(context);
   }
+
 };

--- a/lib/github.js
+++ b/lib/github.js
@@ -13,58 +13,54 @@ async function getPullRequestForHead(github, params) {
 }
 
 module.exports = {
-  async deploy(event, context) {
-    robot.log.trace('fire deployment event');
-
-    const queryObject = {owner:event.payload.repository.owner.login, repo:event.payload.repository.name};
+  async deploy(context) {
+    console.log('fire deployment event');
 
     context.github.repos.createDeploymentStatus(Object.assign({
-      id:event.payload.deployment.id, state:'pending', environment_url:'http://pr' + event.payload.deployment.payload.pull + '-' + event.payload.deployment.payload.branch + '.devnation-demo.apps.rhsademo.net'}, queryObject));
+      id:context.event.payload.deployment.id, state:'pending', environment_url:'http://pr' + context.event.payload.deployment.payload.pull + '-' + context.event.payload.deployment.payload.branch + '.devnation-demo.apps.rhsademo.net'}, context.repo()));
 
     setTimeout(() => {
       context.github.repos.createDeploymentStatus(Object.assign({
-        id:event.payload.deployment.id, state:'success', environment_url:'http://pr' + event.payload.deployment.payload.pull + '-' + event.payload.deployment.payload.branch + '.devnation-demo.apps.rhsademo.net'}, queryObject));
+        id:context.event.payload.deployment.id, state:'success', environment_url:'http://pr' + context.event.payload.deployment.payload.pull + '-' + context.event.payload.deployment.payload.branch + '.devnation-demo.apps.rhsademo.net'}, context.repo()));
     }, 60000);
   },
 
-  async pr_opened(event, context) {
-    robot.log.trace('no GitHub action on pr-open');
+  async pr_opened(context) {
+    console.log('no GitHub action on pr-open');
   },
-  async pr_reopened(event, context) {
-    this.pr_opened(event, context);
+  async pr_reopened(context) {
+    this.pr_opened(context);
   },
-  async push(event, context) {
-    robot.log.trace('push happened.', 'is it relevant to a PR?');
+  async push(context) {
+    console.log('push happened.', 'is it relevant to a PR?');
     if (DEBUG) {
-      robot.info(event);
+      console.log(context.event);
     }
-    const queryObject = {owner:event.payload.repository.owner.name, repo:event.payload.repository.name};
 
-    context.github.repos.createStatus(Object.assign({sha:event.payload.after, state:'success', context:'jsunit', description:'JSUnit tests'}, queryObject));
+    context.github.repos.createStatus(Object.assign({sha:context.event.payload.after, state:'success', context:'jsunit', description:'OpenShift Deployment'}, context.reop()));
 
-    const pull = await getPullRequestForHead(context.github, Object.assign({head:event.payload.ref}, queryObject));
+    const pull = await getPullRequestForHead(context.github, Object.assign({head:context.event.payload.ref}, queryObject));
 
     if (pull === undefined) {
-      robot.log.trace('This push was **NOT** part of a PR!');
+      console.log('This push was **NOT** part of a PR!');
     } else {
-      await this.pr_commits(event, context, pull, queryObject);
+      await this.pr_commits(context, pull, context.reop());
     }
   },
-  async status_for_commit(event, context) {
-    const queryObject = {owner:event.payload.repository.owner.login, repo:event.payload.repository.name};
+  async status_for_commit(context) {
 
-    const status = await context.github.repos.getCombinedStatus(Object.assign({ref:event.payload.ref}, queryObject));
-    robot.log.trace('combined status: ', status.state);
+    const status = await context.github.repos.getCombinedStatus(Object.assign({ref:event.payload.ref}, context.repo()));
+    console.log('combined status: ', status.state);
     if (status.state === 'success') {
-      robot.log.trace(event.payload, '\n\n\n', 'branches---', event.payload.branches[0]);
-      const pull = await getPullRequestForHead(context.github, Object.assign({head:'refs/heads/' + event.payload.branches[0].name}, queryObject));
+      console.log(event.payload, '\n\n\n', 'branches---', context.event.payload.branches[0]);
+      const pull = await getPullRequestForHead(context.github, Object.assign({head:'refs/heads/' + context.event.payload.branches[0].name}, context.repo()));
 
-      this.on_pr_status_success(event, context, pull, queryObject);
+      this.on_pr_status_success(context, pull);
     }
   },
-  async pr_commits(event, context, pull, queryObject) {
-    robot.log.trace('This push **was** part of a PR!');
-    robot.log.trace('Does this branch have statuses related to it?');
+  async pr_commits(context, pull, queryObject) {
+    console.log('This push **was** part of a PR!');
+    console.log('Does this branch have statuses related to it?');
     try {
       await context.github.repos.getProtectedBranchRequiredStatusChecksContexts(Object.assign({branch:pull.head.ref}, queryObject));
     } catch (err) {
@@ -72,17 +68,17 @@ module.exports = {
       if (err.code === 404) {
         // If any are pending, this will also fail. Give
         // the system 4 seconds for statuses to start to report
-        setTimeout(this.on_pr_status_success.bind(null, event, context, pull, queryObject), 4000);
+        setTimeout(this.on_pr_status_success.bind(null, context, pull), 4000);
       }
     }
   },
 
-  async on_pr_status_success(event, context, pull, queryObject) {
-    context.github.repos.createDeployment(Object.assign({ref:event.payload.ref, environment:'staging-pr-' + pull.number, payload:{pull:pull.number, branch:pull.head.ref}}, queryObject));
+  async on_pr_status_success(context, pull) {
+    context.github.repos.createDeployment(Object.assign({ref:context.event.payload.ref, environment:'staging-pr-' + pull.number, payload:{pull:pull.number, branch:pull.head.ref}}, context.reop()));
   },
   async pr_closed() {
   },
   async pr_merge() {
-    robot.log.trace('turn on canary deploy');
+    console.log('turn on canary deploy');
   }
 };

--- a/lib/openshift.js
+++ b/lib/openshift.js
@@ -17,12 +17,19 @@ Async function deploy_complete(event, context, owner, repoName) {
 */
 module.exports = {
   async pr_opened(event) {
-    console.log('os pr(', event.payload.number, ') was', event.payload.action, ': ', event.payload.pull_request.title);
+    console.log('github pr(', event.payload.number, ') was', event.payload.action, ': ', event.payload.pull_request.title);
     console.log('create OpenShift service now!');
     console.log(util.inspect(ocRest));
   /*  OcRest.deploymentconfigs.create({}, {}).then(dc => {
       console.log(util.inspect(dc, false, null));
     }); */
+
+    //create build for this branch
+    //create deployment to read from this image that was built
+    //create route for this deployment
+
+
+    // routes point to services
   },
   async pr_reopened(event) {
     this.pr_opened(event);


### PR DESCRIPTION
Over the next month, The OpenShift-GitHub Branches plugin will reach it's 0.5 milestone :tada:

The first step for that is getting the right packages in page for this work. These packages will continue to be managed while development happens on the 0.4 milestone. Packages are frozen for the 0.5 milestone